### PR TITLE
Add possibility to reuse an existing Markdown header …

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,34 @@ plugins: [
 ];
 ```
 
-additionally, you can pass custom options directly to [mdast-util-toc][mdast-util-toc] like so:
+If you want your table of contents to appear at a specific place in your Markdown file, use the `reuseExistingHeader` option:
+
+```js
+// in your gatsby-config.js
+plugins: [
+  {
+    resolve: 'gatsby-transformer-remark',
+    options: {
+      plugins: [
+        {
+          resolve: 'gatsby-remark-toc',
+          options: {
+            header: 'Table of Contents', // the custom header text
+            reuseExistingHeader: true, // searches for `Table of Contents` in your Markdown file and adds the list right after it
+            include: [
+              'content/**/*.md' // an include glob to match against
+            ]
+          }
+        }
+      ]
+    }
+  }
+];
+```
+
+Use the `orderedList` option if you want to change the list type from `<ul>` to `<ol>`.
+
+Additionally, you can pass custom options directly to [mdast-util-toc][mdast-util-toc] like so:
 
 ```js
 // in your gatsby-config.js

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -158,4 +158,35 @@ describe('custom behavior', () => {
 
     expect(children).toHaveLength(maxDepth);
   });
+  test('it allows for reusing an existing header', () => {
+    let markdownNode = getMarkdownNode(
+      `
+## One
+## ToC
+## Two
+## Three
+  `,
+      'content/example.md'
+    );
+
+    const header = 'ToC';
+
+    addToc(markdownNode, {
+      include: ['content/*.md'],
+      header,
+      useExistingHeader: true
+    });
+
+    const toc = markdownNode.markdownAST.children[2];
+
+    expect(hasTOCHeading(markdownNode.markdownAST, header)).toBe(true);
+
+    expect(markdownNode.markdownAST.children[0].type).toBe('heading');
+    expect(markdownNode.markdownAST.children[1].type).toBe('heading');
+    expect(toc.type).toBe('list');
+    expect(markdownNode.markdownAST.children[3].type).toBe('heading');
+    expect(markdownNode.markdownAST.children[4].type).toBe('heading');
+
+    expect(toc.children).toHaveLength(3);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "gatsby-remark-toc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "author": "Dustin Schau <dustinschau@gmail.com> (https://dustinschau.com)",
+  "contributors": [
+    "Manuel Wieser <office@manuelwieser.com> (https://manu.ninja)"
+  ],
   "license": "MIT",
   "scripts": {
     "precommit": "pretty-quick --staged",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,13 @@ const mm = require('micromatch');
 
 module.exports = function generateTOCNodes(
   { markdownNode, markdownAST },
-  { include = [], header = 'Table of Contents', mdastUtilTocOptions = {} }
+  {
+    include = [],
+    header = 'Table of Contents',
+    useExistingHeader = false,
+    orderedList = false,
+    mdastUtilTocOptions = {}
+  }
 ) {
   const filePath = markdownNode.fileAbsolutePath
     .split(process.cwd())
@@ -15,12 +21,31 @@ module.exports = function generateTOCNodes(
     return;
   }
 
-  const toc = generateTOC(markdownAST, mdastUtilTocOptions).map;
-  const index = markdownAST.children.findIndex(node => node.type !== 'yaml');
+  const index = markdownAST.children.findIndex(node => {
+    if (useExistingHeader) {
+      if (node.type === 'heading') {
+        return node.children.findIndex(child => child.value === header) + 1;
+      }
+      return false;
+    }
+    return node.type !== 'yaml';
+  });
 
-  if (!toc || index < 0) {
+  if (index < 0) {
     return;
   }
+
+  if (useExistingHeader) {
+    markdownAST.children.splice(index, 1);
+  }
+
+  const toc = generateTOC(markdownAST, mdastUtilTocOptions).map;
+
+  if (!toc) {
+    return;
+  }
+
+  toc.ordered = orderedList;
 
   const nodes = [
     header && {


### PR DESCRIPTION
… as well as the option to output an ordered list.
```diff
plugins: [
  {
    resolve: 'gatsby-transformer-remark',
    options: {
      plugins: [
        {
          resolve: 'gatsby-remark-toc',
          options: {
            header: 'Table of Contents',
++          reuseExistingHeader: true|false,
++          orderedList: true|false,
            include: [
              'content/**/*.md'
            ]
          }
        }
      ]
    }
  }
];
```